### PR TITLE
Docs : Swagger에 Cookie Authentication 추가

### DIFF
--- a/server/src/auth/guard/logged-in.guard.ts
+++ b/server/src/auth/guard/logged-in.guard.ts
@@ -1,0 +1,14 @@
+import { CanActivate, ExecutionContext, Injectable } from '@nestjs/common';
+import { Request } from 'express';
+import { Observable } from 'rxjs';
+
+@Injectable()
+export class LoggedInGuard implements CanActivate {
+  canActivate(
+    context: ExecutionContext,
+  ): boolean | Promise<boolean> | Observable<boolean> {
+    const request = context.switchToHttp().getRequest() as Request;
+
+    return request.isAuthenticated();
+  }
+}

--- a/server/src/auth/strategies/local.strategy.ts
+++ b/server/src/auth/strategies/local.strategy.ts
@@ -34,7 +34,7 @@ export class LocalStrategy extends PassportStrategy(Strategy, 'local') {
     }
 
     console.log('here is LocalStrategy2');
-    // 지금 이 done에서 req.user로 user를 못 보낸다.
+
     return done(null, user);
   }
 }

--- a/server/src/controllers/auth.controller.ts
+++ b/server/src/controllers/auth.controller.ts
@@ -1,12 +1,22 @@
-import { Body, Controller, Inject, Post, Req, UseGuards } from '@nestjs/common';
+import {
+  Body,
+  Controller,
+  Get,
+  Inject,
+  Post,
+  Session,
+  UseGuards,
+} from '@nestjs/common';
 import {
   ApiBody,
+  ApiCookieAuth,
   ApiCreatedResponse,
   ApiOkResponse,
   ApiOperation,
   ApiTags,
   ApiUnauthorizedResponse,
 } from '@nestjs/swagger';
+import { LoggedInGuard } from 'src/auth/guard/logged-in.guard';
 import { LocalAuthGuard } from 'src/auth/guard/local-auth.guard';
 import { Users } from 'src/decorators/user.decorator';
 import { LogInUserDto } from 'src/dtos/auth/login.user.dto';
@@ -42,10 +52,12 @@ export class AuthController {
   })
   @UseGuards(LocalAuthGuard)
   @Post('login')
-  async logIn(@Users() user) {
-    return user;
+  async logIn(@Users() user, @Session() session) {
+    console.log(session.id);
+    return { user, sessionId: session.id };
   }
 
+  @ApiCookieAuth()
   @ApiOperation({
     summary: 'Local 회원가입 api',
     description: '유저의 이메일과 일치하는 메일이 없으면 회원가입에 성공한다.',
@@ -62,5 +74,13 @@ export class AuthController {
       email: user.email,
       password: user.password,
     });
+  }
+
+  // TODO: Swagger에서 세션 로그인이 잘 작동하는지 확인하기 위한 용도이므로, 나중에 삭제해야한다.
+  @ApiCookieAuth()
+  @UseGuards(LoggedInGuard)
+  @Get('hi')
+  async hi() {
+    return 'hi';
   }
 }

--- a/server/src/settings/session/init.session.ts
+++ b/server/src/settings/session/init.session.ts
@@ -3,6 +3,7 @@ import { ConfigService } from '@nestjs/config';
 import * as session from 'express-session';
 import * as connectRedis from 'connect-redis';
 import { Redis } from 'ioredis';
+import * as passport from 'passport';
 
 export function setUpSession(app: INestApplication): void {
   const configService = app.get<ConfigService>(ConfigService);
@@ -28,10 +29,13 @@ export function setUpSession(app: INestApplication): void {
       }),
       cookie: {
         httpOnly: true,
-        secure: true,
-        maxAge: 40000,
+        secure: false, // TODO: https로 사용할거면 true로 바꿔야한다. 지금은 로컬에서 사용하니 false로 해둔다.
+        maxAge: 1000 * 60 * 30, // 쿠키 유효기간: 30분
         path: '/',
       },
     }),
   );
+
+  app.use(passport.initialize());
+  app.use(passport.session());
 }

--- a/server/src/settings/swagger/init.swagger.ts
+++ b/server/src/settings/swagger/init.swagger.ts
@@ -3,7 +3,7 @@ import { DocumentBuilder, SwaggerModule } from '@nestjs/swagger';
 
 export function setUpSwagger(app: INestApplication): void {
   const options = new DocumentBuilder()
-    .addBearerAuth()
+    .addCookieAuth('connect.sid')
     .setTitle('BanangBanang API docs')
     .setDescription('배낭배낭 API 문서입니다.')
     .setVersion('0.0.1')


### PR DESCRIPTION
## 개요

- Swagger 이용시 로그인을 해야 이용할 수 있는 기능들을 사용할 수 있게 하기 위해 Cookie Authentication 기능 추가

## ✅ 작업 내용

- Swagger setting에서 addCookieAuth('connect.sid') 추가
- 로그인이 되어 있는지 체크하는 LoggedInGuard 추가

## 🔨 변경 로직

- session의 cookie.secure : false로 변경
  - true로 하면 https에만 적용되기 때문에 로컬에서 하는 http 통신에는 쿠키가 적용이 안됨
  - 후에 실 서비스를 운용할 때에 secure : true로 변경할 것

## 🧨 관련 이슈

- close #7
