### PR TITLE
Feat : Read Article List 관련 API 작성

### DIFF
--- a/server/src/common/error-message.ts
+++ b/server/src/common/error-message.ts
@@ -6,4 +6,9 @@ export const ERROR_MESSAGE = {
   FAIL_TO_GOOGLE_LOGIN: { code: 400, message: '해당 유저를 찾을 수 없습니다.' },
   //article
   FAIL_TO_JOB_POSTING: { code: 400, message: 'JOB POSTING에 실패했어요!' },
+  //articleRepository
+  FAIL_TO_GET_ARTICLE: {
+    code: 400,
+    message: '게시글 목록을 불러오지 못했습니다.',
+  },
 };

--- a/server/src/controllers/article.controller.ts
+++ b/server/src/controllers/article.controller.ts
@@ -15,6 +15,7 @@ import {
   ApiTags,
 } from '@nestjs/swagger';
 import { LoggedInGuard } from 'src/auth/guard/logged-in.guard';
+import { ApiQueries } from 'src/decorators/api-queries.decorator';
 import {
   ArticleControllerInboundPort,
   ARTICLE_CONTROLLER_INBOUNT_PORT,
@@ -58,8 +59,36 @@ export class ArticleController {
   }
 
   // 게시글을 타입, 지역 별로 가져올 수도 있어야 한다.
+  @ApiQueries(
+    [
+      { name: 'perPage', description: '페이지 당 게시글 개수' },
+      { name: 'currentPage', description: '현재 페이지 번호' },
+    ],
+    [
+      {
+        name: 'userId',
+        description: '해당 유저 아이디의 게시글 조회시 필요',
+      },
+      { name: 'articleTypeId', description: '게시글 유형별 조회시 필요' },
+      { name: 'articleAreaId', description: '게시글 지역별 조회시 필요' },
+      { name: 'order', description: '게시글 정렬 방향' },
+      { name: 'type', description: '게시글 정렬 기준' },
+    ],
+  )
   @Get()
-  async readArticles(@Query() query: ReadArticlesInboundPortInputDto) {
-    return await this.articleControllerInboundPort.readArticles(query);
+  async readArticles(@Query() query) {
+    const params: ReadArticlesInboundPortInputDto = {
+      userId: query?.userId,
+      articleTypeId: query?.articleTypeId,
+      articleAreaId: query?.articleAreaId,
+      order: {
+        type: query?.type,
+        order: query?.order,
+      },
+      currentPage: query?.currentPage,
+      perPage: query?.perPage,
+    };
+
+    return await this.articleControllerInboundPort.readArticles(params);
   }
 }

--- a/server/src/controllers/article.controller.ts
+++ b/server/src/controllers/article.controller.ts
@@ -1,8 +1,17 @@
-import { Body, Controller, Inject, Post, UseGuards } from '@nestjs/common';
+import {
+  Body,
+  Controller,
+  Get,
+  Inject,
+  Post,
+  Query,
+  UseGuards,
+} from '@nestjs/common';
 import {
   ApiBody,
   ApiCreatedResponse,
   ApiOperation,
+  ApiQuery,
   ApiTags,
 } from '@nestjs/swagger';
 import { LoggedInGuard } from 'src/auth/guard/logged-in.guard';
@@ -10,6 +19,7 @@ import {
   ArticleControllerInboundPort,
   ARTICLE_CONTROLLER_INBOUNT_PORT,
   CreateArticleInboundPortInputDto,
+  ReadArticlesInboundPortInputDto,
 } from 'src/inbound-ports/article/article-controller.inbound-port';
 
 @ApiTags('게시글 API')
@@ -45,5 +55,11 @@ export class ArticleController {
   async createArticle(@Body() body: CreateArticleInboundPortInputDto) {
     console.log('create article controller');
     return await this.articleControllerInboundPort.createArticle(body);
+  }
+
+  // 게시글을 타입, 지역 별로 가져올 수도 있어야 한다.
+  @Get()
+  async readArticles(@Query() query: ReadArticlesInboundPortInputDto) {
+    return await this.articleControllerInboundPort.readArticles(query);
   }
 }

--- a/server/src/decorators/api-queries.decorator.ts
+++ b/server/src/decorators/api-queries.decorator.ts
@@ -1,0 +1,25 @@
+import { applyDecorators } from '@nestjs/common';
+import { ApiQuery } from '@nestjs/swagger';
+
+export const ApiQueries = (
+  requiredProperties: { name: string; description: string }[],
+  nonRequiredProperties: { name: string; description: string }[],
+) => {
+  const required = requiredProperties.map((el) => {
+    return ApiQuery({
+      name: el.name,
+      required: true,
+      description: el.description,
+    });
+  });
+
+  const nonRequired = nonRequiredProperties.map((el) => {
+    return ApiQuery({
+      name: el.name,
+      required: false,
+      description: el.description,
+    });
+  });
+
+  return applyDecorators(...required, ...nonRequired);
+};

--- a/server/src/inbound-ports/article/article-controller.inbound-port.ts
+++ b/server/src/inbound-ports/article/article-controller.inbound-port.ts
@@ -14,8 +14,31 @@ export type CreateArticleInboundPortOutputDto = {
   articleId: string;
 };
 
+export type ReadArticlesInboundPortInputDto = {
+  userId?: string;
+  articleTypeId?: number;
+  articleAreaId?: number;
+  order?: {
+    type: string;
+    order: 'ASC' | 'DESC';
+  };
+  perPage: number;
+  currentPage: number;
+};
+export type ReadArticlesInboundPortOutputDto = {
+  articles: any[];
+  articleCount: number;
+  perPage: number;
+  currentPage: number;
+  pageCount: number; // 총 몇 페이지까지 있는지 = 마지막 페이지 번호
+};
+
 export interface ArticleControllerInboundPort {
   createArticle(
     params: CreateArticleInboundPortInputDto,
   ): Promise<CreateArticleInboundPortOutputDto>;
+
+  readArticles(
+    params: ReadArticlesInboundPortInputDto,
+  ): Promise<ReadArticlesInboundPortOutputDto>;
 }

--- a/server/src/outbound-ports/article/article-repository.outbound-port.ts
+++ b/server/src/outbound-ports/article/article-repository.outbound-port.ts
@@ -25,6 +25,22 @@ export type SaveJobPostingOutboundPortOutputDto = {
   articleId: string;
 };
 
+export type FindAllArticlesOutboundPortInputDto = {
+  userId?: string;
+  articleTypeId?: number;
+  articleAreaId?: number;
+  order?: {
+    type: string;
+    order: 'ASC' | 'DESC';
+  };
+  perPage: number;
+  currentPage: number;
+};
+export type FindAllArticlesOutboundPortOutputDto = {
+  articles: any[];
+  articleCount: number;
+};
+
 export interface ArticleRepositoryOutboundPort {
   saveCommonArticle(
     params: SaveCommonArticleOutboundPortInputDto,
@@ -33,4 +49,8 @@ export interface ArticleRepositoryOutboundPort {
   saveJobPosting(
     params: SaveJogPostingOutboundPortInputDto,
   ): Promise<SaveJobPostingOutboundPortOutputDto>;
+
+  findAllArticles(
+    params: FindAllArticlesOutboundPortInputDto,
+  ): Promise<FindAllArticlesOutboundPortOutputDto>;
 }

--- a/server/src/repositories/article.repository.ts
+++ b/server/src/repositories/article.repository.ts
@@ -55,38 +55,38 @@ export class ArticleRepository implements ArticleRepositoryOutboundPort {
       let query = this.articleRepository
         .createQueryBuilder('a')
         .select([
-          'a.id as id',
-          'a.title as title',
-          'a.createdAt as createdAt',
-          'a.userId as userId',
-          'a.articleTypeId as articleTypeId',
-          'a.articleAreaId as articleAreaId',
+          'a.id as "id"',
+          'a.title as "title"',
+          'a.createdAt as "createdAt"',
+          'a.userId as "userId"',
+          'a.articleTypeId as "articleTypeId"',
+          'a.articleAreaId as "articleAreaId"',
         ]);
 
       // 유저 Id에 따른 게시글 리스트 불러오기 (undefined시 모든 유저의 게시글을 불러온다)
       if (params.userId) {
-        query = query.where('a.userId = :userId', { userId: params.userId });
+        query = query.where('userId = :userId', { userId: params.userId });
       }
 
       // 게시글 유형에 따른 필터 (undefined시 모든 유형의 게시글을 불러온다)
       if (params.articleTypeId) {
-        query = query.andWhere('a.articleTypeId = :articleTypeId', {
+        query = query.andWhere('articleTypeId = :articleTypeId', {
           articleTypeId: params.articleTypeId,
         });
       }
 
       // 게시글 지역에 따른 필터 (undefined시 모든 지역의 게시글을 불러온다)
       if (params.articleAreaId) {
-        query = query.andWhere('a.articleAreaId = :articleAreaId', {
+        query = query.andWhere('articleAreaId = :articleAreaId', {
           articleAreaId: params.articleAreaId,
         });
       }
 
       // 순서 정렬, order 속성에는 디폴트값으로 createdAt과 DESC가 들어갈 것
       if (!params.order.type) {
-        params['order'] = { type: 'createdAt', order: 'DESC' };
+        params['order'] = { type: '"createdAt"', order: 'DESC' };
       }
-      query = query.orderBy(`a.${params.order.type}`, `${params.order.order}`);
+      query = query.orderBy(`${params.order.type}`, `${params.order.order}`);
 
       // 몇 번째 페이지를 불러오는지 설정
       query = query.skip(params.perPage * (params.currentPage - 1));

--- a/server/src/repositories/article.repository.ts
+++ b/server/src/repositories/article.repository.ts
@@ -55,12 +55,12 @@ export class ArticleRepository implements ArticleRepositoryOutboundPort {
       let query = this.articleRepository
         .createQueryBuilder('a')
         .select([
-          'a.id',
-          'a.title',
-          'a.createdAt',
-          'a.userId',
-          'a.articleTypeId',
-          'a.articleAreaId',
+          'a.id as id',
+          'a.title as title',
+          'a.createdAt as createdAt',
+          'a.userId as userId',
+          'a.articleTypeId as articleTypeId',
+          'a.articleAreaId as articleAreaId',
         ]);
 
       // 유저 Id에 따른 게시글 리스트 불러오기 (undefined시 모든 유저의 게시글을 불러온다)
@@ -82,9 +82,6 @@ export class ArticleRepository implements ArticleRepositoryOutboundPort {
         });
       }
 
-      // 조건에 맞는 게시글의 총 개수를 반환
-      const articleCount = await query.getCount();
-
       // 순서 정렬, order 속성에는 디폴트값으로 createdAt과 DESC가 들어갈 것
       if (!params.order.type) {
         params['order'] = { type: 'createdAt', order: 'DESC' };
@@ -98,6 +95,9 @@ export class ArticleRepository implements ArticleRepositoryOutboundPort {
       query = query.take(params.perPage);
 
       const articles = await query.getRawMany();
+
+      // 조건에 맞는 게시글의 총 개수를 반환
+      const articleCount = await query.getCount();
 
       return { articles, articleCount };
     } catch (e) {

--- a/server/src/repositories/article.repository.ts
+++ b/server/src/repositories/article.repository.ts
@@ -86,7 +86,7 @@ export class ArticleRepository implements ArticleRepositoryOutboundPort {
       const articleCount = await query.getCount();
 
       // 순서 정렬, order 속성에는 디폴트값으로 createdAt과 DESC가 들어갈 것
-      if (!params.order) {
+      if (!params.order.type) {
         params['order'] = { type: 'createdAt', order: 'DESC' };
       }
       query = query.orderBy(`a.${params.order.type}`, `${params.order.order}`);

--- a/server/src/repositories/article.repository.ts
+++ b/server/src/repositories/article.repository.ts
@@ -1,8 +1,11 @@
-import { Injectable } from '@nestjs/common';
+import { BadRequestException, Injectable } from '@nestjs/common';
 import { InjectRepository } from '@nestjs/typeorm';
+import { ERROR_MESSAGE } from 'src/common/error-message';
 import { ArticleEntity } from 'src/entities/article/article.entity';
 import {
   ArticleRepositoryOutboundPort,
+  FindAllArticlesOutboundPortInputDto,
+  FindAllArticlesOutboundPortOutputDto,
   SaveCommonArticleOutboundPortInputDto,
   SaveCommonArticleOutboundPortOutputDto,
   SaveJobPostingOutboundPortOutputDto,
@@ -43,5 +46,63 @@ export class ArticleRepository implements ArticleRepositoryOutboundPort {
       },
     });
     return { articleId: article.id };
+  }
+
+  async findAllArticles(
+    params: FindAllArticlesOutboundPortInputDto,
+  ): Promise<FindAllArticlesOutboundPortOutputDto> {
+    try {
+      let query = this.articleRepository
+        .createQueryBuilder('a')
+        .select([
+          'a.id',
+          'a.title',
+          'a.createdAt',
+          'a.userId',
+          'a.articleTypeId',
+          'a.articleAreaId',
+        ]);
+
+      // 유저 Id에 따른 게시글 리스트 불러오기 (undefined시 모든 유저의 게시글을 불러온다)
+      if (params.userId) {
+        query = query.where('a.userId = :userId', { userId: params.userId });
+      }
+
+      // 게시글 유형에 따른 필터 (undefined시 모든 유형의 게시글을 불러온다)
+      if (params.articleTypeId) {
+        query = query.andWhere('a.articleTypeId = :articleTypeId', {
+          articleTypeId: params.articleTypeId,
+        });
+      }
+
+      // 게시글 지역에 따른 필터 (undefined시 모든 지역의 게시글을 불러온다)
+      if (params.articleAreaId) {
+        query = query.andWhere('a.articleAreaId = :articleAreaId', {
+          articleAreaId: params.articleAreaId,
+        });
+      }
+
+      // 조건에 맞는 게시글의 총 개수를 반환
+      const articleCount = await query.getCount();
+
+      // 순서 정렬, order 속성에는 디폴트값으로 createdAt과 DESC가 들어갈 것
+      if (!params.order) {
+        params['order'] = { type: 'createdAt', order: 'DESC' };
+      }
+      query = query.orderBy(`a.${params.order.type}`, `${params.order.order}`);
+
+      // 몇 번째 페이지를 불러오는지 설정
+      query = query.skip(params.perPage * (params.currentPage - 1));
+
+      // 몇 개의 게시글을 불러오는지 설정
+      query = query.take(params.perPage);
+
+      const articles = await query.getRawMany();
+
+      return { articles, articleCount };
+    } catch (e) {
+      console.log(e);
+      throw new BadRequestException(ERROR_MESSAGE.FAIL_TO_GET_ARTICLE);
+    }
   }
 }

--- a/server/src/services/article.service.ts
+++ b/server/src/services/article.service.ts
@@ -5,6 +5,8 @@ import {
   ArticleControllerInboundPort,
   CreateArticleInboundPortInputDto,
   CreateArticleInboundPortOutputDto,
+  ReadArticlesInboundPortInputDto,
+  ReadArticlesInboundPortOutputDto,
 } from 'src/inbound-ports/article/article-controller.inbound-port';
 import {
   ArticleRepositoryOutboundPort,
@@ -45,5 +47,22 @@ export class ArticleService implements ArticleControllerInboundPort {
         expirationDate: params.expirationDate,
       });
     }
+  }
+
+  async readArticles(
+    params: ReadArticlesInboundPortInputDto,
+  ): Promise<ReadArticlesInboundPortOutputDto> {
+    const { articles, articleCount } =
+      await this.articleRepositoryOutboundPort.findAllArticles(params);
+
+    const res: ReadArticlesInboundPortOutputDto = {
+      articleCount: articleCount,
+      articles: articles,
+      currentPage: params.currentPage,
+      pageCount: Math.ceil(articleCount / params.perPage),
+      perPage: params.perPage,
+    };
+
+    return res;
   }
 }

--- a/server/src/unit-test/article/article.controller.spec.ts
+++ b/server/src/unit-test/article/article.controller.spec.ts
@@ -3,10 +3,13 @@ import {
   ArticleControllerInboundPort,
   CreateArticleInboundPortInputDto,
   CreateArticleInboundPortOutputDto,
+  ReadArticlesInboundPortInputDto,
+  ReadArticlesInboundPortOutputDto,
 } from 'src/inbound-ports/article/article-controller.inbound-port';
 
 type MockArticleControllerInboundPortParamType = {
   createArticle?: CreateArticleInboundPortOutputDto;
+  readArticles?: ReadArticlesInboundPortOutputDto;
 };
 
 class MockArticleControllerInboundPort implements ArticleControllerInboundPort {
@@ -19,6 +22,11 @@ class MockArticleControllerInboundPort implements ArticleControllerInboundPort {
     params: CreateArticleInboundPortInputDto,
   ): Promise<CreateArticleInboundPortOutputDto> {
     return this.result.createArticle;
+  }
+  async readArticles(
+    params: ReadArticlesInboundPortInputDto,
+  ): Promise<ReadArticlesInboundPortOutputDto> {
+    return this.result.readArticles;
   }
 }
 
@@ -41,5 +49,103 @@ describe('ArticleController Spec', () => {
     const res = await articleController.createArticle(body);
 
     expect(res).toStrictEqual({ articleId: '1' });
+  });
+
+  test('Read Articles', async () => {
+    const articles = [
+      {
+        id: '1',
+        title: 'Test Article Title',
+        content: 'Test Article Content',
+        userId: '1',
+        articleAreaId: 1,
+        articleTypeId: 1,
+        createdAt: new Date('2023-01-01'),
+      },
+      {
+        id: '2',
+        title: 'Test Article Title2',
+        content: 'Test Article Content2',
+        userId: '2',
+        articleAreaId: 2,
+        articleTypeId: 2,
+        createdAt: new Date('2023-01-02'),
+      },
+      {
+        id: '3',
+        title: 'Test Article Title2',
+        content: 'Test Article Content2',
+        userId: '3',
+        articleAreaId: 1,
+        articleTypeId: 2,
+        createdAt: new Date('2023-01-03'),
+      },
+      {
+        id: '4',
+        title: 'Test Article Title2',
+        content: 'Test Article Content2',
+        userId: '4',
+        articleAreaId: 2,
+        articleTypeId: 1,
+        createdAt: new Date('2023-01-04'),
+      },
+      {
+        id: '5',
+        title: 'Test Article Title2',
+        content: 'Test Article Content2',
+        userId: '5',
+        articleAreaId: 2,
+        articleTypeId: 2,
+        createdAt: new Date('2023-01-05'),
+      },
+      {
+        id: '6',
+        title: 'Test Article Title2',
+        content: 'Test Article Content2',
+        userId: '6',
+        articleAreaId: 2,
+        articleTypeId: 2,
+        createdAt: new Date('2023-01-06'),
+      },
+      {
+        id: '7',
+        title: 'Test Article Title2',
+        content: 'Test Article Content2',
+        userId: '7',
+        articleAreaId: 1,
+        articleTypeId: 1,
+        createdAt: new Date('2023-01-07'),
+      },
+    ];
+
+    const perPage = 7;
+    const currentPage = 1;
+
+    const query = {
+      perPage: perPage,
+      currentPage: currentPage,
+    };
+
+    const articleController = new ArticleController(
+      new MockArticleControllerInboundPort({
+        readArticles: {
+          articleCount: articles.length,
+          articles: articles,
+          currentPage: currentPage,
+          pageCount: Math.ceil(articles.length / perPage),
+          perPage: perPage,
+        },
+      }),
+    );
+
+    const res = await articleController.readArticles(query);
+
+    expect(res).toStrictEqual({
+      articleCount: articles.length,
+      articles: articles,
+      currentPage: currentPage,
+      pageCount: Math.ceil(articles.length / perPage),
+      perPage: perPage,
+    });
   });
 });

--- a/server/src/unit-test/article/article.service.spec.ts
+++ b/server/src/unit-test/article/article.service.spec.ts
@@ -1,7 +1,13 @@
 import { ARTICLE_TYPE } from 'src/common/article/article-type.constant';
-import { CreateArticleInboundPortInputDto } from 'src/inbound-ports/article/article-controller.inbound-port';
+import { ArticleEntity } from 'src/entities/article/article.entity';
+import {
+  CreateArticleInboundPortInputDto,
+  ReadArticlesInboundPortInputDto,
+} from 'src/inbound-ports/article/article-controller.inbound-port';
 import {
   ArticleRepositoryOutboundPort,
+  FindAllArticlesOutboundPortInputDto,
+  FindAllArticlesOutboundPortOutputDto,
   SaveCommonArticleOutboundPortInputDto,
   SaveCommonArticleOutboundPortOutputDto,
   SaveJobPostingOutboundPortOutputDto,
@@ -12,6 +18,7 @@ import { ArticleService } from 'src/services/article.service';
 type MockArticleRepositoryOutboundPortParamType = {
   saveCommonArticle?: SaveCommonArticleOutboundPortOutputDto;
   saveJogPosting?: SaveJobPostingOutboundPortOutputDto;
+  findAllArticles?: FindAllArticlesOutboundPortOutputDto;
 };
 
 class MockArticleRepositoryOutboundPort
@@ -22,7 +29,6 @@ class MockArticleRepositoryOutboundPort
   constructor(result: MockArticleRepositoryOutboundPortParamType) {
     this.result = result;
   }
-
   async saveCommonArticle(
     params: SaveCommonArticleOutboundPortInputDto,
   ): Promise<SaveCommonArticleOutboundPortOutputDto> {
@@ -32,6 +38,11 @@ class MockArticleRepositoryOutboundPort
     params: SaveJogPostingOutboundPortInputDto,
   ): Promise<SaveJobPostingOutboundPortOutputDto> {
     return this.result.saveJogPosting;
+  }
+  async findAllArticles(
+    params: FindAllArticlesOutboundPortInputDto,
+  ): Promise<FindAllArticlesOutboundPortOutputDto> {
+    return this.result.findAllArticles;
   }
 }
 
@@ -76,5 +87,94 @@ describe('ArticleService Spec', () => {
     const res = await articleService.createArticle(article);
 
     expect(res).toStrictEqual({ articleId: '1' });
+  });
+
+  test('read Article List', async () => {
+    const articles = [
+      {
+        id: '1',
+        title: 'Test Article Title',
+        content: 'Test Article Content',
+        userId: '1',
+        articleAreaId: 1,
+        articleTypeId: 1,
+        createdAt: new Date('2023-01-01'),
+      },
+      {
+        id: '2',
+        title: 'Test Article Title2',
+        content: 'Test Article Content2',
+        userId: '2',
+        articleAreaId: 2,
+        articleTypeId: 2,
+        createdAt: new Date('2023-01-02'),
+      },
+      {
+        id: '3',
+        title: 'Test Article Title2',
+        content: 'Test Article Content2',
+        userId: '3',
+        articleAreaId: 1,
+        articleTypeId: 2,
+        createdAt: new Date('2023-01-03'),
+      },
+      {
+        id: '4',
+        title: 'Test Article Title2',
+        content: 'Test Article Content2',
+        userId: '4',
+        articleAreaId: 2,
+        articleTypeId: 1,
+        createdAt: new Date('2023-01-04'),
+      },
+      {
+        id: '5',
+        title: 'Test Article Title2',
+        content: 'Test Article Content2',
+        userId: '5',
+        articleAreaId: 2,
+        articleTypeId: 2,
+        createdAt: new Date('2023-01-05'),
+      },
+      {
+        id: '6',
+        title: 'Test Article Title2',
+        content: 'Test Article Content2',
+        userId: '6',
+        articleAreaId: 2,
+        articleTypeId: 2,
+        createdAt: new Date('2023-01-06'),
+      },
+      {
+        id: '7',
+        title: 'Test Article Title2',
+        content: 'Test Article Content2',
+        userId: '7',
+        articleAreaId: 1,
+        articleTypeId: 1,
+        createdAt: new Date('2023-01-07'),
+      },
+    ];
+
+    const params: ReadArticlesInboundPortInputDto = {
+      currentPage: 1,
+      perPage: 7,
+    };
+
+    const articleService = new ArticleService(
+      new MockArticleRepositoryOutboundPort({
+        findAllArticles: { articles, articleCount: articles.length },
+      }),
+    );
+
+    const res = await articleService.readArticles(params);
+
+    expect(res).toStrictEqual({
+      articleCount: 7,
+      articles: articles,
+      currentPage: 1,
+      pageCount: Math.ceil(articles.length / params.perPage),
+      perPage: params.perPage,
+    });
   });
 });


### PR DESCRIPTION
## 개요

- 게시글 목록을 불러올 수 있다.

## ✅ 작업 내용

- 게시글 목록 불러오는 api 작성
  - userId, articleTypeId, articleAreaId에 따라 원하는 게시글 목록을 불러오기 가능
  - type과 order 쿼리를 통해 어떤 칼럼을 중심으로 어떤차순으로 게시글을 불러올지 설정 가능
- readArticles Controller test 작성
- readArticles Service test 작성
- readArticles에 Swagger 작성
- ArticleRepository에 게시글 목록을 불러오는 findAllArticles 함수 작성
- ApiQuery를 여러개 받는 ApiQueries 데코레이터 작성

## 🔨 변경 로직

- 게시글 목록을 불러오지 못했을 때의 에러 메시지 추가 

## 🧨 관련 이슈

- #12 
