### PR TITLE
Feat : Read One Article API 작성

### DIFF
--- a/server/src/controllers/article.controller.ts
+++ b/server/src/controllers/article.controller.ts
@@ -61,6 +61,11 @@ export class ArticleController {
   }
 
   // 게시글을 타입, 지역 별로 가져올 수도 있어야 한다.
+  @ApiOperation({
+    summary: '게시글 목록 조회 api',
+    description:
+      '게시글 유형, 지역, 사용자, 정렬 등에 따라 게시글 목록을 조회한다.',
+  })
   @ApiQueries(
     [
       { name: 'perPage', description: '페이지 당 게시글 개수' },
@@ -94,6 +99,15 @@ export class ArticleController {
     return await this.articleControllerInboundPort.readArticles(params);
   }
 
+  @ApiOperation({
+    summary: '게시글 조회 api',
+    description: '게시글 id로 해당 게시글 조회',
+  })
+  @ApiParam({
+    name: 'id',
+    required: true,
+    description: '게시글 id',
+  })
   @Get(':id')
   async readAnArticle(@Param('id') id: string) {
     return this.articleControllerInboundPort.readAnArticle({ articleId: id });

--- a/server/src/controllers/article.controller.ts
+++ b/server/src/controllers/article.controller.ts
@@ -3,6 +3,7 @@ import {
   Controller,
   Get,
   Inject,
+  Param,
   Post,
   Query,
   UseGuards,
@@ -11,6 +12,7 @@ import {
   ApiBody,
   ApiCreatedResponse,
   ApiOperation,
+  ApiParam,
   ApiQuery,
   ApiTags,
 } from '@nestjs/swagger';
@@ -90,5 +92,10 @@ export class ArticleController {
     };
 
     return await this.articleControllerInboundPort.readArticles(params);
+  }
+
+  @Get(':id')
+  async readAnArticle(@Param('id') id: string) {
+    return this.articleControllerInboundPort.readAnArticle({ articleId: id });
   }
 }

--- a/server/src/entities/comment/comment.entity.ts
+++ b/server/src/entities/comment/comment.entity.ts
@@ -6,7 +6,7 @@ import { UserEntity } from '../user/user.entity';
 @Entity('COMMENT')
 export class CommentEntity extends CommonBigPKEntity {
   @Column('bigint', { unique: false, nullable: true })
-  commentId: string | null;
+  parentId: string | null;
 
   @Column('text', { unique: false, nullable: false })
   content: string;

--- a/server/src/inbound-ports/article/article-controller.inbound-port.ts
+++ b/server/src/inbound-ports/article/article-controller.inbound-port.ts
@@ -33,6 +33,44 @@ export type ReadArticlesInboundPortOutputDto = {
   pageCount: number; // 총 몇 페이지까지 있는지 = 마지막 페이지 번호
 };
 
+export type ReadAnArticleInboundPortInputDto = {
+  articleId: string;
+};
+export type ReadAnArticleInboundPortOutputDto = {
+  id: string;
+  createdAt: Date;
+  updatedAt: Date;
+  title: string;
+  content: string;
+  user: {
+    id: string;
+  };
+  articleArea: {
+    id: number;
+    area: string;
+  };
+  articleType: {
+    id: number;
+    type: string;
+  };
+  comments?: {
+    id: string;
+    createdAt: Date;
+    updatedAt: Date;
+    userId: string;
+    content: string;
+    parentId: string;
+    depth: number;
+  }[];
+  jobPosting?: {
+    id: string;
+    createdAt: Date;
+    updatedAt: Date;
+    companyName: string;
+    expirationDate: Date;
+  };
+};
+
 export interface ArticleControllerInboundPort {
   createArticle(
     params: CreateArticleInboundPortInputDto,
@@ -41,4 +79,8 @@ export interface ArticleControllerInboundPort {
   readArticles(
     params: ReadArticlesInboundPortInputDto,
   ): Promise<ReadArticlesInboundPortOutputDto>;
+
+  readAnArticle(
+    params: ReadAnArticleInboundPortInputDto,
+  ): Promise<ReadAnArticleInboundPortOutputDto>;
 }

--- a/server/src/outbound-ports/article/article-repository.outbound-port.ts
+++ b/server/src/outbound-ports/article/article-repository.outbound-port.ts
@@ -44,7 +44,40 @@ export type FindAllArticlesOutboundPortOutputDto = {
 export type FindOneArticleOutboundPortInputDto = {
   articleId: string;
 };
-export type FindOneArticleOutboundPortOutputDto = {};
+export type FindOneArticleOutboundPortOutputDto = {
+  id: string;
+  createdAt: Date;
+  updatedAt: Date;
+  title: string;
+  content: string;
+  user: {
+    id: string;
+  };
+  articleArea: {
+    id: number;
+    area: string;
+  };
+  articleType: {
+    id: number;
+    type: string;
+  };
+  comments?: {
+    id: string;
+    createdAt: Date;
+    updatedAt: Date;
+    userId: string;
+    content: string;
+    parentId: string;
+    depth: number;
+  }[];
+  jobPosting?: {
+    id: string;
+    createdAt: Date;
+    updatedAt: Date;
+    companyName: string;
+    expirationDate: Date;
+  };
+};
 
 export interface ArticleRepositoryOutboundPort {
   saveCommonArticle(

--- a/server/src/outbound-ports/article/article-repository.outbound-port.ts
+++ b/server/src/outbound-ports/article/article-repository.outbound-port.ts
@@ -41,6 +41,11 @@ export type FindAllArticlesOutboundPortOutputDto = {
   articleCount: number;
 };
 
+export type FindOneArticleOutboundPortInputDto = {
+  articleId: string;
+};
+export type FindOneArticleOutboundPortOutputDto = {};
+
 export interface ArticleRepositoryOutboundPort {
   saveCommonArticle(
     params: SaveCommonArticleOutboundPortInputDto,
@@ -53,4 +58,8 @@ export interface ArticleRepositoryOutboundPort {
   findAllArticles(
     params: FindAllArticlesOutboundPortInputDto,
   ): Promise<FindAllArticlesOutboundPortOutputDto>;
+
+  findOneArticle(
+    params: FindOneArticleOutboundPortInputDto,
+  ): Promise<FindOneArticleOutboundPortOutputDto>;
 }

--- a/server/src/repositories/article.repository.ts
+++ b/server/src/repositories/article.repository.ts
@@ -113,11 +113,18 @@ export class ArticleRepository implements ArticleRepositoryOutboundPort {
   ): Promise<FindOneArticleOutboundPortOutputDto> {
     const article = await this.articleRepository
       .createQueryBuilder('a')
-      .select()
-      .innerJoinAndMapOne('a.user', 'a.user', 'u', 'u.id = a.userId')
+      .select([
+        'a.id',
+        'a.createdAt',
+        'a.updatedAt',
+        'a.title',
+        'a.content',
+        'u.id',
+      ])
+      .innerJoin('a.user', 'u', 'u.id = a.userId')
       .innerJoinAndSelect('a.articleArea', 'aa', 'a.articleAreaId = aa.id')
       .innerJoinAndSelect('a.articleType', 'at', 'a.articleTypeId = at.id')
-      .leftJoinAndMapMany('a.comments', 'a.comments', 'c', 'c.articleId = a.id')
+      .leftJoinAndSelect('a.comments', 'c', 'a.id = c.articleId')
       .leftJoinAndSelect('a.jobPosting', 'j', 'j.articleId = a.id')
       .where('a.id = :articleId', { articleId: params.articleId })
       .take(1)

--- a/server/src/repositories/article.repository.ts
+++ b/server/src/repositories/article.repository.ts
@@ -6,6 +6,8 @@ import {
   ArticleRepositoryOutboundPort,
   FindAllArticlesOutboundPortInputDto,
   FindAllArticlesOutboundPortOutputDto,
+  FindOneArticleOutboundPortInputDto,
+  FindOneArticleOutboundPortOutputDto,
   SaveCommonArticleOutboundPortInputDto,
   SaveCommonArticleOutboundPortOutputDto,
   SaveJobPostingOutboundPortOutputDto,
@@ -104,5 +106,23 @@ export class ArticleRepository implements ArticleRepositoryOutboundPort {
       console.log(e);
       throw new BadRequestException(ERROR_MESSAGE.FAIL_TO_GET_ARTICLE);
     }
+  }
+
+  async findOneArticle(
+    params: FindOneArticleOutboundPortInputDto,
+  ): Promise<FindOneArticleOutboundPortOutputDto> {
+    const article = await this.articleRepository
+      .createQueryBuilder('a')
+      .select()
+      .innerJoinAndMapOne('a.user', 'a.user', 'u', 'u.id = a.userId')
+      .innerJoinAndSelect('a.articleArea', 'aa', 'a.articleAreaId = aa.id')
+      .innerJoinAndSelect('a.articleType', 'at', 'a.articleTypeId = at.id')
+      .leftJoinAndMapMany('a.comments', 'a.comments', 'c', 'c.articleId = a.id')
+      .leftJoinAndSelect('a.jobPosting', 'j', 'j.articleId = a.id')
+      .where('a.id = :articleId', { articleId: params.articleId })
+      .take(1)
+      .getOne();
+
+    return article;
   }
 }

--- a/server/src/services/article.service.ts
+++ b/server/src/services/article.service.ts
@@ -5,6 +5,8 @@ import {
   ArticleControllerInboundPort,
   CreateArticleInboundPortInputDto,
   CreateArticleInboundPortOutputDto,
+  ReadAnArticleInboundPortInputDto,
+  ReadAnArticleInboundPortOutputDto,
   ReadArticlesInboundPortInputDto,
   ReadArticlesInboundPortOutputDto,
 } from 'src/inbound-ports/article/article-controller.inbound-port';
@@ -64,5 +66,13 @@ export class ArticleService implements ArticleControllerInboundPort {
     };
 
     return res;
+  }
+
+  async readAnArticle(
+    params: ReadAnArticleInboundPortInputDto,
+  ): Promise<ReadAnArticleInboundPortOutputDto> {
+    return this.articleRepositoryOutboundPort.findOneArticle({
+      articleId: params.articleId,
+    });
   }
 }

--- a/server/src/unit-test/article/article.controller.spec.ts
+++ b/server/src/unit-test/article/article.controller.spec.ts
@@ -3,6 +3,8 @@ import {
   ArticleControllerInboundPort,
   CreateArticleInboundPortInputDto,
   CreateArticleInboundPortOutputDto,
+  ReadAnArticleInboundPortInputDto,
+  ReadAnArticleInboundPortOutputDto,
   ReadArticlesInboundPortInputDto,
   ReadArticlesInboundPortOutputDto,
 } from 'src/inbound-ports/article/article-controller.inbound-port';
@@ -10,6 +12,7 @@ import {
 type MockArticleControllerInboundPortParamType = {
   createArticle?: CreateArticleInboundPortOutputDto;
   readArticles?: ReadArticlesInboundPortOutputDto;
+  readAnArticle?: ReadAnArticleInboundPortOutputDto;
 };
 
 class MockArticleControllerInboundPort implements ArticleControllerInboundPort {
@@ -27,6 +30,11 @@ class MockArticleControllerInboundPort implements ArticleControllerInboundPort {
     params: ReadArticlesInboundPortInputDto,
   ): Promise<ReadArticlesInboundPortOutputDto> {
     return this.result.readArticles;
+  }
+  async readAnArticle(
+    params: ReadAnArticleInboundPortInputDto,
+  ): Promise<ReadAnArticleInboundPortOutputDto> {
+    return this.result.readAnArticle;
   }
 }
 
@@ -147,5 +155,38 @@ describe('ArticleController Spec', () => {
       pageCount: Math.ceil(articles.length / perPage),
       perPage: perPage,
     });
+  });
+
+  test('Read An Article', async () => {
+    const articleId = '1';
+
+    const article: ReadAnArticleInboundPortOutputDto = {
+      id: articleId,
+      createdAt: new Date(),
+      updatedAt: new Date(),
+      title: 'test title',
+      content: 'hello, world!',
+      user: {
+        id: '1',
+      },
+      articleArea: {
+        id: 1,
+        area: 'Seoul',
+      },
+      articleType: {
+        id: 1,
+        type: 'Job Posting',
+      },
+      comments: [],
+      jobPosting: null,
+    };
+
+    const articleController = new ArticleController(
+      new MockArticleControllerInboundPort({ readAnArticle: article }),
+    );
+
+    const res = await articleController.readAnArticle(articleId);
+
+    expect(res).toStrictEqual(article);
   });
 });

--- a/server/src/unit-test/article/article.service.spec.ts
+++ b/server/src/unit-test/article/article.service.spec.ts
@@ -8,6 +8,8 @@ import {
   ArticleRepositoryOutboundPort,
   FindAllArticlesOutboundPortInputDto,
   FindAllArticlesOutboundPortOutputDto,
+  FindOneArticleOutboundPortInputDto,
+  FindOneArticleOutboundPortOutputDto,
   SaveCommonArticleOutboundPortInputDto,
   SaveCommonArticleOutboundPortOutputDto,
   SaveJobPostingOutboundPortOutputDto,
@@ -19,6 +21,7 @@ type MockArticleRepositoryOutboundPortParamType = {
   saveCommonArticle?: SaveCommonArticleOutboundPortOutputDto;
   saveJogPosting?: SaveJobPostingOutboundPortOutputDto;
   findAllArticles?: FindAllArticlesOutboundPortOutputDto;
+  findOneArticle?: FindOneArticleOutboundPortOutputDto;
 };
 
 class MockArticleRepositoryOutboundPort
@@ -43,6 +46,11 @@ class MockArticleRepositoryOutboundPort
     params: FindAllArticlesOutboundPortInputDto,
   ): Promise<FindAllArticlesOutboundPortOutputDto> {
     return this.result.findAllArticles;
+  }
+  async findOneArticle(
+    params: FindOneArticleOutboundPortInputDto,
+  ): Promise<FindOneArticleOutboundPortOutputDto> {
+    return this.result.findOneArticle;
   }
 }
 
@@ -176,5 +184,38 @@ describe('ArticleService Spec', () => {
       pageCount: Math.ceil(articles.length / params.perPage),
       perPage: params.perPage,
     });
+  });
+
+  test('Read One Article', async () => {
+    const articleId = '1';
+
+    const article: FindOneArticleOutboundPortOutputDto = {
+      id: articleId,
+      createdAt: new Date(),
+      updatedAt: new Date(),
+      title: 'test title',
+      content: 'hello, world!',
+      user: {
+        id: '1',
+      },
+      articleArea: {
+        id: 1,
+        area: 'Seoul',
+      },
+      articleType: {
+        id: 1,
+        type: 'Job Posting',
+      },
+      comments: [],
+      jobPosting: null,
+    };
+
+    const articleService = new ArticleService(
+      new MockArticleRepositoryOutboundPort({ findOneArticle: article }),
+    );
+
+    const res = await articleService.readAnArticle({ articleId: articleId });
+
+    expect(res).toStrictEqual(article);
   });
 });


### PR DESCRIPTION
## 개요

- 단일 게시글을 읽는 api 작성

## ✅ 작업 내용

- 단일 게시글을 읽는 api 작성
  - id를 param으로 받아서 해당 id를 가진 article을 가져온다.
- readAnArticle Controller test 작성
- readAnArticle Service test 작성
- readAnArticle Swagger 작성
- articleRepository에 findOneArticle 함수 작성


## 🔨 변경 로직

- comment Entity의 commentId를 parentId로 수정

## 🧨 관련 이슈

- #12 
