### PR TITLE
Feat : Delete Article API 작성

### DIFF
--- a/server/src/common/error-message.ts
+++ b/server/src/common/error-message.ts
@@ -11,4 +11,8 @@ export const ERROR_MESSAGE = {
     code: 400,
     message: '게시글 목록을 불러오지 못했습니다.',
   },
+  FAIL_TO_DELETE_ARTICLE: {
+    code: 400,
+    message: '게시글 삭제를 실패하였습니다.',
+  },
 };

--- a/server/src/controllers/article.controller.ts
+++ b/server/src/controllers/article.controller.ts
@@ -1,6 +1,7 @@
 import {
   Body,
   Controller,
+  Delete,
   Get,
   Inject,
   Param,
@@ -152,6 +153,27 @@ export class ArticleController {
     return this.articleControllerInboundPort.updateArticle({
       userId: user.id,
       ...body,
+      articleId: articleId,
+    });
+  }
+
+  @ApiOperation({
+    summary: '게시글 삭제 api',
+    description: '게시글 id로 해당 개시글 삭제',
+  })
+  @ApiParam({
+    name: 'id',
+    required: true,
+    description: '게시글 id',
+  })
+  @UseGuards(LoggedInGuard)
+  @Delete(':id')
+  async deleteArticle(
+    @Param('id') articleId: string,
+    @Users() user: GetUserIdDto,
+  ) {
+    return this.articleControllerInboundPort.removeArticle({
+      userId: user.id,
       articleId: articleId,
     });
   }

--- a/server/src/inbound-ports/article/article-controller.inbound-port.ts
+++ b/server/src/inbound-ports/article/article-controller.inbound-port.ts
@@ -85,6 +85,13 @@ export type UpdateArticleInboundPortOutputDto = {
   affected: number | undefined;
 };
 
+export type RemoveArticleInboundPortInputDto = {
+  userId: string;
+  articleId: string;
+};
+export type RemoveArticleInboundPortOutputDto = {
+  affected: number | undefined;
+};
 export interface ArticleControllerInboundPort {
   createArticle(
     params: CreateArticleInboundPortInputDto,
@@ -101,4 +108,8 @@ export interface ArticleControllerInboundPort {
   updateArticle(
     params: UpdateArticleInboundPortInputDto,
   ): Promise<UpdateArticleInboundPortOutputDto>;
+
+  removeArticle(
+    params: RemoveArticleInboundPortInputDto,
+  ): Promise<RemoveArticleInboundPortOutputDto>;
 }

--- a/server/src/outbound-ports/article/article-repository.outbound-port.ts
+++ b/server/src/outbound-ports/article/article-repository.outbound-port.ts
@@ -105,6 +105,14 @@ export type UpdateJobPostingOutboundPortOutputDto = {
   affected: number | undefined;
 };
 
+export type RemoveArticleOutboundPortInputDto = {
+  userId: string;
+  articleId: string;
+};
+export type RemoveArticleOutboundPortOutputDto = {
+  affected: number | undefined;
+};
+
 export interface ArticleRepositoryOutboundPort {
   saveCommonArticle(
     params: SaveCommonArticleOutboundPortInputDto,
@@ -129,4 +137,8 @@ export interface ArticleRepositoryOutboundPort {
   updateJobPosting(
     params: UpdateJobPostingOutboundPortInputDto,
   ): Promise<UpdateJobPostingOutboundPortOutputDto>;
+
+  removeArticle(
+    params: RemoveArticleOutboundPortInputDto,
+  ): Promise<RemoveArticleOutboundPortOutputDto>;
 }

--- a/server/src/repositories/article.repository.ts
+++ b/server/src/repositories/article.repository.ts
@@ -4,6 +4,8 @@ import { ERROR_MESSAGE } from 'src/common/error-message';
 import { ArticleEntity } from 'src/entities/article/article.entity';
 import {
   ArticleRepositoryOutboundPort,
+  RemoveArticleOutboundPortInputDto,
+  RemoveArticleOutboundPortOutputDto,
   FindAllArticlesOutboundPortInputDto,
   FindAllArticlesOutboundPortOutputDto,
   FindOneArticleOutboundPortInputDto,
@@ -178,6 +180,22 @@ export class ArticleRepository implements ArticleRepositoryOutboundPort {
     );
 
     console.log(article);
+
+    return { affected: article?.affected };
+  }
+
+  async removeArticle(
+    params: RemoveArticleOutboundPortInputDto,
+  ): Promise<RemoveArticleOutboundPortOutputDto> {
+    const article = await this.articleRepository.softDelete({
+      id: params.articleId,
+      userId: params.userId,
+    });
+
+    console.log(article);
+    if (article?.affected === 0) {
+      throw new BadRequestException(ERROR_MESSAGE.FAIL_TO_DELETE_ARTICLE);
+    }
 
     return { affected: article?.affected };
   }

--- a/server/src/services/article.service.ts
+++ b/server/src/services/article.service.ts
@@ -9,6 +9,8 @@ import {
   ReadAnArticleInboundPortOutputDto,
   ReadArticlesInboundPortInputDto,
   ReadArticlesInboundPortOutputDto,
+  RemoveArticleInboundPortInputDto,
+  RemoveArticleInboundPortOutputDto,
   UpdateArticleInboundPortInputDto,
   UpdateArticleInboundPortOutputDto,
 } from 'src/inbound-ports/article/article-controller.inbound-port';
@@ -101,5 +103,16 @@ export class ArticleService implements ArticleControllerInboundPort {
         expirationDate: params.expirationDate,
       });
     }
+  }
+
+  async removeArticle(
+    params: RemoveArticleInboundPortInputDto,
+  ): Promise<RemoveArticleInboundPortOutputDto> {
+    const article = await this.articleRepositoryOutboundPort.removeArticle({
+      userId: params.userId,
+      articleId: params.articleId,
+    });
+
+    return { affected: article?.affected };
   }
 }

--- a/server/src/unit-test/article/article.controller.spec.ts
+++ b/server/src/unit-test/article/article.controller.spec.ts
@@ -7,6 +7,8 @@ import {
   ReadAnArticleInboundPortOutputDto,
   ReadArticlesInboundPortInputDto,
   ReadArticlesInboundPortOutputDto,
+  RemoveArticleInboundPortInputDto,
+  RemoveArticleInboundPortOutputDto,
   UpdateArticleInboundPortInputDto,
   UpdateArticleInboundPortOutputDto,
 } from 'src/inbound-ports/article/article-controller.inbound-port';
@@ -16,6 +18,7 @@ type MockArticleControllerInboundPortParamType = {
   readArticles?: ReadArticlesInboundPortOutputDto;
   readAnArticle?: ReadAnArticleInboundPortOutputDto;
   updateArticle?: UpdateArticleInboundPortOutputDto;
+  removeArticle?: RemoveArticleInboundPortOutputDto;
 };
 
 class MockArticleControllerInboundPort implements ArticleControllerInboundPort {
@@ -43,6 +46,11 @@ class MockArticleControllerInboundPort implements ArticleControllerInboundPort {
     params: UpdateArticleInboundPortInputDto,
   ): Promise<UpdateArticleInboundPortOutputDto> {
     return this.result.updateArticle;
+  }
+  async removeArticle(
+    params: RemoveArticleInboundPortInputDto,
+  ): Promise<RemoveArticleInboundPortOutputDto> {
+    return this.result.removeArticle;
   }
 }
 
@@ -220,6 +228,22 @@ describe('ArticleController Spec', () => {
     const res = await articleController.updateArticle(articleId, body, {
       id: '1',
     });
+
+    expect(res).toStrictEqual({ affected: 1 });
+  });
+
+  test('Remove Article', async () => {
+    const affected: RemoveArticleInboundPortOutputDto = {
+      affected: 1,
+    };
+
+    const articleId = '1';
+
+    const articleController = new ArticleController(
+      new MockArticleControllerInboundPort({ removeArticle: affected }),
+    );
+
+    const res = await articleController.deleteArticle(articleId, { id: '1' });
 
     expect(res).toStrictEqual({ affected: 1 });
   });

--- a/server/src/unit-test/article/article.service.spec.ts
+++ b/server/src/unit-test/article/article.service.spec.ts
@@ -10,6 +10,8 @@ import {
   FindAllArticlesOutboundPortOutputDto,
   FindOneArticleOutboundPortInputDto,
   FindOneArticleOutboundPortOutputDto,
+  RemoveArticleOutboundPortInputDto,
+  RemoveArticleOutboundPortOutputDto,
   SaveCommonArticleOutboundPortInputDto,
   SaveCommonArticleOutboundPortOutputDto,
   SaveJobPostingOutboundPortOutputDto,
@@ -28,6 +30,7 @@ type MockArticleRepositoryOutboundPortParamType = {
   findOneArticle?: FindOneArticleOutboundPortOutputDto;
   updateCommonArticle?: UpdateCommonArticleOutboundPortOutputDto;
   updateJobPosting?: UpdateJobPostingOutboundPortOutputDto;
+  removeArticle?: RemoveArticleOutboundPortOutputDto;
 };
 
 class MockArticleRepositoryOutboundPort
@@ -67,6 +70,11 @@ class MockArticleRepositoryOutboundPort
     params: UpdateJobPostingOutboundPortInputDto,
   ): Promise<UpdateJobPostingOutboundPortOutputDto> {
     return this.result.updateJobPosting;
+  }
+  async removeArticle(
+    params: RemoveArticleOutboundPortInputDto,
+  ): Promise<RemoveArticleOutboundPortOutputDto> {
+    return this.result.removeArticle;
   }
 }
 
@@ -275,6 +283,22 @@ describe('ArticleService Spec', () => {
     );
 
     const res = await articleService.updateArticle(article);
+
+    expect(res).toStrictEqual({ affected: 1 });
+  });
+
+  test('Remove Article', async () => {
+    const affected: RemoveArticleOutboundPortOutputDto = {
+      affected: 1,
+    };
+
+    const articleId = '1';
+
+    const articleService = new ArticleService(
+      new MockArticleRepositoryOutboundPort({ removeArticle: affected }),
+    );
+
+    const res = await articleService.removeArticle({ articleId, userId: '1' });
 
     expect(res).toStrictEqual({ affected: 1 });
   });


### PR DESCRIPTION
## 개요

- 게시글을 Delete할 수 있다.

## ✅ 작업 내용

- Delete Article Error message 작성
- Delete Article api 작성
- Delete Article in Controller logic test
- Remove Article in Service logic test
- Add swagger

## 🔨 변경 로직

- 

## 🧨 관련 이슈

- close #12 
