### PR TITLE
Feat: Get Applicants By Article Id API 작성

### DIFF
--- a/server/src/controllers/article.controller.ts
+++ b/server/src/controllers/article.controller.ts
@@ -122,6 +122,15 @@ export class ArticleController {
     return this.articleControllerInboundPort.readAnArticle({ articleId: id });
   }
 
+  @ApiOperation({
+    summary: '게시글 공고의 지원자 조회 api',
+    description: '게시글 id로 해당 게시글 공고의 지원자 조회',
+  })
+  @ApiParam({
+    name: 'id',
+    required: true,
+    description: '게시글 id',
+  })
   @UseGuards(LoggedInGuard)
   @Get(':id/applicants')
   async readApplicantsByArticleId(

--- a/server/src/controllers/article.controller.ts
+++ b/server/src/controllers/article.controller.ts
@@ -38,6 +38,8 @@ export class ArticleController {
     private readonly articleControllerInboundPort: ArticleControllerInboundPort,
   ) {}
 
+  //NOTE: Create
+
   @ApiOperation({
     summary: '게시글 작성 api',
     description: 'articleTypeId에 따라 다른 게시글 생성',
@@ -64,6 +66,8 @@ export class ArticleController {
     console.log('create article controller');
     return await this.articleControllerInboundPort.createArticle(body);
   }
+
+  // NOTE: Read
 
   // 게시글을 타입, 지역 별로 가져올 수도 있어야 한다.
   @ApiOperation({
@@ -118,6 +122,18 @@ export class ArticleController {
     return this.articleControllerInboundPort.readAnArticle({ articleId: id });
   }
 
+  @UseGuards(LoggedInGuard)
+  @Get(':id/applicants')
+  async readApplicantsByArticleId(
+    @Param('id') articleId: string,
+    @Users() user: GetUserIdDto,
+  ) {
+    const params = { articleId, userId: user.id };
+
+    return this.articleControllerInboundPort.readApplicantsByArticleId(params);
+  }
+
+  // NOTE: Update
   @ApiOperation({
     summary: '게시글 수정 api',
     description: '게시글 id로 해당 게시글 수정',
@@ -156,6 +172,8 @@ export class ArticleController {
       articleId: articleId,
     });
   }
+
+  // NOTE: Delete
 
   @ApiOperation({
     summary: '게시글 삭제 api',

--- a/server/src/inbound-ports/article/article-controller.inbound-port.ts
+++ b/server/src/inbound-ports/article/article-controller.inbound-port.ts
@@ -92,6 +92,22 @@ export type RemoveArticleInboundPortInputDto = {
 export type RemoveArticleInboundPortOutputDto = {
   affected: number | undefined;
 };
+
+export type ReadApplicantsByArticleIdInboundPortInputDto = {
+  articleId: string;
+  userId: string;
+};
+export type ReadApplicantsByArticleIdInboundPortOutputDto = {
+  applicants: Array<{
+    id: string;
+    name: string;
+    birth: Date;
+    content: string;
+    userId: string;
+    applicantTypeId: number;
+  }>;
+};
+
 export interface ArticleControllerInboundPort {
   createArticle(
     params: CreateArticleInboundPortInputDto,
@@ -112,4 +128,8 @@ export interface ArticleControllerInboundPort {
   removeArticle(
     params: RemoveArticleInboundPortInputDto,
   ): Promise<RemoveArticleInboundPortOutputDto>;
+
+  readApplicantsByArticleId(
+    params: ReadApplicantsByArticleIdInboundPortInputDto,
+  ): Promise<ReadApplicantsByArticleIdInboundPortOutputDto>;
 }

--- a/server/src/inbound-ports/article/article-controller.inbound-port.ts
+++ b/server/src/inbound-ports/article/article-controller.inbound-port.ts
@@ -1,3 +1,5 @@
+import { ArticleEntity } from 'src/entities/article/article.entity';
+
 export const ARTICLE_CONTROLLER_INBOUNT_PORT =
   'ARTICLE_CONTROLLER_INBOUNT_PORT' as const;
 

--- a/server/src/modules/article.module.ts
+++ b/server/src/modules/article.module.ts
@@ -1,14 +1,17 @@
 import { Module } from '@nestjs/common';
 import { TypeOrmModule } from '@nestjs/typeorm';
 import { ArticleController } from 'src/controllers/article.controller';
+import { ApplicantEntity } from 'src/entities/applicant/applicant.entity';
 import { ArticleEntity } from 'src/entities/article/article.entity';
 import { ARTICLE_CONTROLLER_INBOUNT_PORT } from 'src/inbound-ports/article/article-controller.inbound-port';
+import { APPLICANT_REPOSITORY_OUTBOUND_PORT } from 'src/outbound-ports/applicant/applicant-repository.outbound-port.ts';
 import { ARTICLE_REPOSITORY_OUTBOUND_PORT } from 'src/outbound-ports/article/article-repository.outbound-port';
+import { ApplicantRepository } from 'src/repositories/applicant.repository.ts';
 import { ArticleRepository } from 'src/repositories/article.repository';
 import { ArticleService } from 'src/services/article.service';
 
 @Module({
-  imports: [TypeOrmModule.forFeature([ArticleEntity])],
+  imports: [TypeOrmModule.forFeature([ArticleEntity, ApplicantEntity])],
   controllers: [ArticleController],
   providers: [
     {
@@ -18,6 +21,10 @@ import { ArticleService } from 'src/services/article.service';
     {
       provide: ARTICLE_REPOSITORY_OUTBOUND_PORT,
       useClass: ArticleRepository,
+    },
+    {
+      provide: APPLICANT_REPOSITORY_OUTBOUND_PORT,
+      useClass: ApplicantRepository,
     },
     ArticleService,
   ],

--- a/server/src/outbound-ports/applicant/applicant-repository.outbound-port.ts.ts
+++ b/server/src/outbound-ports/applicant/applicant-repository.outbound-port.ts.ts
@@ -18,8 +18,27 @@ export type SaveJobPostingApplicantOutboundPortOutputDto = {
   };
 };
 
+export type FindApplicantsByArticleIdOutboundPortInputDto = {
+  articleId: string;
+  userId: string;
+};
+export type FindApplicantsByArticleIdOutboundPortOutputDto = {
+  applicants: Array<{
+    id: string;
+    name: string;
+    birth: Date;
+    content: string;
+    userId: string;
+    applicantTypeId: number;
+  }>;
+};
+
 export interface ApplicantRepositoryOutboundPort {
   saveJobPostingApplicant(
     params: SaveJobPostingApplicantOutboundPortInputDto,
   ): Promise<SaveJobPostingApplicantOutboundPortOutputDto>;
+
+  findApplicantsByArticleId(
+    params: FindApplicantsByArticleIdOutboundPortInputDto,
+  ): Promise<FindApplicantsByArticleIdOutboundPortOutputDto>;
 }

--- a/server/src/repositories/applicant.repository.ts.ts
+++ b/server/src/repositories/applicant.repository.ts.ts
@@ -3,6 +3,8 @@ import { InjectRepository } from '@nestjs/typeorm';
 import { ApplicantEntity } from 'src/entities/applicant/applicant.entity';
 import {
   ApplicantRepositoryOutboundPort,
+  FindApplicantsByArticleIdOutboundPortInputDto,
+  FindApplicantsByArticleIdOutboundPortOutputDto,
   SaveJobPostingApplicantOutboundPortInputDto,
   SaveJobPostingApplicantOutboundPortOutputDto,
 } from 'src/outbound-ports/applicant/applicant-repository.outbound-port.ts';
@@ -28,5 +30,20 @@ export class ApplicantRepository implements ApplicantRepositoryOutboundPort {
     });
 
     return { applicant };
+  }
+
+  async findApplicantsByArticleId(
+    params: FindApplicantsByArticleIdOutboundPortInputDto,
+  ): Promise<FindApplicantsByArticleIdOutboundPortOutputDto> {
+    const applicants = await this.applicantRepository
+      .createQueryBuilder('ap')
+      .select()
+      .where('ap.articleId = :articleId', { articleId: params.articleId })
+      .innerJoinAndSelect('ap.article', 'a', `a.userId = ${params.userId}`)
+      .getMany();
+
+    console.log(applicants);
+
+    return { applicants };
   }
 }

--- a/server/src/services/article.service.ts
+++ b/server/src/services/article.service.ts
@@ -7,6 +7,8 @@ import {
   CreateArticleInboundPortOutputDto,
   ReadAnArticleInboundPortInputDto,
   ReadAnArticleInboundPortOutputDto,
+  ReadApplicantsByArticleIdInboundPortInputDto,
+  ReadApplicantsByArticleIdInboundPortOutputDto,
   ReadArticlesInboundPortInputDto,
   ReadArticlesInboundPortOutputDto,
   RemoveArticleInboundPortInputDto,
@@ -14,6 +16,10 @@ import {
   UpdateArticleInboundPortInputDto,
   UpdateArticleInboundPortOutputDto,
 } from 'src/inbound-ports/article/article-controller.inbound-port';
+import {
+  ApplicantRepositoryOutboundPort,
+  APPLICANT_REPOSITORY_OUTBOUND_PORT,
+} from 'src/outbound-ports/applicant/applicant-repository.outbound-port.ts';
 import {
   ArticleRepositoryOutboundPort,
   ARTICLE_REPOSITORY_OUTBOUND_PORT,
@@ -24,6 +30,9 @@ export class ArticleService implements ArticleControllerInboundPort {
   constructor(
     @Inject(ARTICLE_REPOSITORY_OUTBOUND_PORT)
     private readonly articleRepositoryOutboundPort: ArticleRepositoryOutboundPort,
+
+    @Inject(APPLICANT_REPOSITORY_OUTBOUND_PORT)
+    private readonly applicantRepositoryOutboundPort: ApplicantRepositoryOutboundPort,
   ) {}
 
   async createArticle(
@@ -114,5 +123,13 @@ export class ArticleService implements ArticleControllerInboundPort {
     });
 
     return { affected: article?.affected };
+  }
+
+  async readApplicantsByArticleId(
+    params: ReadApplicantsByArticleIdInboundPortInputDto,
+  ): Promise<ReadApplicantsByArticleIdInboundPortOutputDto> {
+    return this.applicantRepositoryOutboundPort.findApplicantsByArticleId(
+      params,
+    );
   }
 }

--- a/server/src/unit-test/applicant/applicant.service.spec.ts
+++ b/server/src/unit-test/applicant/applicant.service.spec.ts
@@ -1,5 +1,7 @@
 import {
   ApplicantRepositoryOutboundPort,
+  FindApplicantsByArticleIdOutboundPortInputDto,
+  FindApplicantsByArticleIdOutboundPortOutputDto,
   SaveJobPostingApplicantOutboundPortInputDto,
   SaveJobPostingApplicantOutboundPortOutputDto,
 } from 'src/outbound-ports/applicant/applicant-repository.outbound-port.ts';
@@ -7,9 +9,10 @@ import { ApplicantService } from 'src/services/applicant.service';
 
 type MockApplicantRepositoryOutboundPortParamType = {
   saveJobPostingApplicant?: SaveJobPostingApplicantOutboundPortOutputDto;
+  findApplicantsByArticleId?: FindApplicantsByArticleIdOutboundPortOutputDto;
 };
 
-class MockApplicantRepositoryOutboundPort
+export class MockApplicantRepositoryOutboundPort
   implements ApplicantRepositoryOutboundPort
 {
   private readonly result: MockApplicantRepositoryOutboundPortParamType;
@@ -22,6 +25,11 @@ class MockApplicantRepositoryOutboundPort
     params: SaveJobPostingApplicantOutboundPortInputDto,
   ): Promise<SaveJobPostingApplicantOutboundPortOutputDto> {
     return this.result.saveJobPostingApplicant;
+  }
+  async findApplicantsByArticleId(
+    params: FindApplicantsByArticleIdOutboundPortInputDto,
+  ): Promise<FindApplicantsByArticleIdOutboundPortOutputDto> {
+    return this.result.findApplicantsByArticleId;
   }
 }
 

--- a/server/src/unit-test/article/article.controller.spec.ts
+++ b/server/src/unit-test/article/article.controller.spec.ts
@@ -5,6 +5,8 @@ import {
   CreateArticleInboundPortOutputDto,
   ReadAnArticleInboundPortInputDto,
   ReadAnArticleInboundPortOutputDto,
+  ReadApplicantsByArticleIdInboundPortInputDto,
+  ReadApplicantsByArticleIdInboundPortOutputDto,
   ReadArticlesInboundPortInputDto,
   ReadArticlesInboundPortOutputDto,
   RemoveArticleInboundPortInputDto,
@@ -19,6 +21,7 @@ type MockArticleControllerInboundPortParamType = {
   readAnArticle?: ReadAnArticleInboundPortOutputDto;
   updateArticle?: UpdateArticleInboundPortOutputDto;
   removeArticle?: RemoveArticleInboundPortOutputDto;
+  readApplicantsByArticleId?: ReadApplicantsByArticleIdInboundPortOutputDto;
 };
 
 class MockArticleControllerInboundPort implements ArticleControllerInboundPort {
@@ -51,6 +54,11 @@ class MockArticleControllerInboundPort implements ArticleControllerInboundPort {
     params: RemoveArticleInboundPortInputDto,
   ): Promise<RemoveArticleInboundPortOutputDto> {
     return this.result.removeArticle;
+  }
+  async readApplicantsByArticleId(
+    params: ReadApplicantsByArticleIdInboundPortInputDto,
+  ): Promise<ReadApplicantsByArticleIdInboundPortOutputDto> {
+    return this.result.readApplicantsByArticleId;
   }
 }
 
@@ -246,5 +254,32 @@ describe('ArticleController Spec', () => {
     const res = await articleController.deleteArticle(articleId, { id: '1' });
 
     expect(res).toStrictEqual({ affected: 1 });
+  });
+
+  test('Read Applicants By Article Id', async () => {
+    const applicants: ReadApplicantsByArticleIdInboundPortOutputDto = {
+      applicants: [
+        {
+          id: '1',
+          name: 'test applicant',
+          birth: new Date('2000-01-01'),
+          content: 'test applying content',
+          userId: '2',
+          applicantTypeId: 1,
+        },
+      ],
+    };
+
+    const articleController = new ArticleController(
+      new MockArticleControllerInboundPort({
+        readApplicantsByArticleId: applicants,
+      }),
+    );
+
+    const res = await articleController.readApplicantsByArticleId('2', {
+      id: '2',
+    });
+
+    expect(res).toStrictEqual(applicants);
   });
 });

--- a/server/src/unit-test/article/article.service.spec.ts
+++ b/server/src/unit-test/article/article.service.spec.ts
@@ -22,6 +22,7 @@ import {
   UpdateJobPostingOutboundPortOutputDto,
 } from 'src/outbound-ports/article/article-repository.outbound-port';
 import { ArticleService } from 'src/services/article.service';
+import { MockApplicantRepositoryOutboundPort } from '../applicant/applicant.service.spec';
 
 type MockArticleRepositoryOutboundPortParamType = {
   saveCommonArticle?: SaveCommonArticleOutboundPortOutputDto;
@@ -92,6 +93,7 @@ describe('ArticleService Spec', () => {
       new MockArticleRepositoryOutboundPort({
         saveCommonArticle: { articleId: '1' },
       }),
+      new MockApplicantRepositoryOutboundPort({}),
     );
 
     const res = await articleService.createArticle(article);
@@ -114,6 +116,7 @@ describe('ArticleService Spec', () => {
       new MockArticleRepositoryOutboundPort({
         saveJogPosting: { articleId: '1' },
       }),
+      new MockApplicantRepositoryOutboundPort({}),
     );
 
     const res = await articleService.createArticle(article);
@@ -197,6 +200,7 @@ describe('ArticleService Spec', () => {
       new MockArticleRepositoryOutboundPort({
         findAllArticles: { articles, articleCount: articles.length },
       }),
+      new MockApplicantRepositoryOutboundPort({}),
     );
 
     const res = await articleService.readArticles(params);
@@ -236,6 +240,7 @@ describe('ArticleService Spec', () => {
 
     const articleService = new ArticleService(
       new MockArticleRepositoryOutboundPort({ findOneArticle: article }),
+      new MockApplicantRepositoryOutboundPort({}),
     );
 
     const res = await articleService.readAnArticle({ articleId: articleId });
@@ -257,6 +262,7 @@ describe('ArticleService Spec', () => {
       new MockArticleRepositoryOutboundPort({
         updateCommonArticle: { affected: 1 },
       }),
+      new MockApplicantRepositoryOutboundPort({}),
     );
 
     const res = await articleService.updateArticle(article);
@@ -280,6 +286,7 @@ describe('ArticleService Spec', () => {
       new MockArticleRepositoryOutboundPort({
         updateJobPosting: { affected: 1 },
       }),
+      new MockApplicantRepositoryOutboundPort({}),
     );
 
     const res = await articleService.updateArticle(article);
@@ -296,6 +303,7 @@ describe('ArticleService Spec', () => {
 
     const articleService = new ArticleService(
       new MockArticleRepositoryOutboundPort({ removeArticle: affected }),
+      new MockApplicantRepositoryOutboundPort({}),
     );
 
     const res = await articleService.removeArticle({ articleId, userId: '1' });

--- a/server/src/unit-test/article/article.service.spec.ts
+++ b/server/src/unit-test/article/article.service.spec.ts
@@ -4,6 +4,7 @@ import {
   CreateArticleInboundPortInputDto,
   ReadArticlesInboundPortInputDto,
 } from 'src/inbound-ports/article/article-controller.inbound-port';
+import { FindApplicantsByArticleIdOutboundPortOutputDto } from 'src/outbound-ports/applicant/applicant-repository.outbound-port.ts';
 import {
   ArticleRepositoryOutboundPort,
   FindAllArticlesOutboundPortInputDto,
@@ -309,5 +310,34 @@ describe('ArticleService Spec', () => {
     const res = await articleService.removeArticle({ articleId, userId: '1' });
 
     expect(res).toStrictEqual({ affected: 1 });
+  });
+
+  test('Read Applicants By Article Id', async () => {
+    const applicants: FindApplicantsByArticleIdOutboundPortOutputDto = {
+      applicants: [
+        {
+          id: '1',
+          name: 'test applicant',
+          birth: new Date('2000-01-01'),
+          content: 'test applying content',
+          userId: '2',
+          applicantTypeId: 1,
+        },
+      ],
+    };
+
+    const articleService = new ArticleService(
+      new MockArticleRepositoryOutboundPort({}),
+      new MockApplicantRepositoryOutboundPort({
+        findApplicantsByArticleId: applicants,
+      }),
+    );
+
+    const res = await articleService.readApplicantsByArticleId({
+      articleId: '1',
+      userId: '2',
+    });
+
+    expect(res).toStrictEqual(applicants);
   });
 });


### PR DESCRIPTION
## 개요

- 공고 게시글을 올린 작성자가 해당 공고에 대한 지원자들을 볼 수 있다.

## ✅ 작업 내용

- Applicant Repository에 findApplicantsByArticleId 함수 추가
- Article Service에 readApplicantsByArticleId 함수 추가
- Article Controller에 readApplicantsByArticleId 함수 추가
- Article Module에 종속성 관련 파일들 import
- Add Swagger
- readApplicantsByArticleId test in Article Controller
- readApplicantsByArticleId test in Article Service

## 🔨 변경 로직

- Article Service에 Applicant Repository 주입

## 🧨 관련 이슈

- close #13 
