### PR TITLE
Test : User Id로 해당 유저의 댓글 목록 조회 API 작성

### DIFF
--- a/server/src/unit-test/user/user.controller.spec.ts
+++ b/server/src/unit-test/user/user.controller.spec.ts
@@ -48,9 +48,55 @@ describe('UserController Spec', () => {
       new MockUserControllerInboundPort({ readCommentsByUserId: comments }),
     );
 
-    const res = await userController.readCommentsByUserId({
+    const res = await userController.getOwnComments({
       id: '1',
     });
+
+    expect(res).toStrictEqual([
+      {
+        articleId: '1',
+        content: '1 test comment',
+        createdAt: new Date('2023-01-01'),
+        updatedAt: new Date('2023-01-01'),
+        id: '1',
+        userId: '1',
+      },
+      {
+        articleId: '2',
+        content: '2 test comment',
+        createdAt: new Date('2023-01-01'),
+        updatedAt: new Date('2023-01-01'),
+        id: '2',
+        userId: '1',
+      },
+    ]);
+  });
+
+  test('Read Comments By User Id', async () => {
+    const comments: ReadCommentsByUserIdInboundPortOutputDto = [
+      {
+        articleId: '1',
+        content: '1 test comment',
+        createdAt: new Date('2023-01-01'),
+        updatedAt: new Date('2023-01-01'),
+        id: '1',
+        userId: '1',
+      },
+      {
+        articleId: '2',
+        content: '2 test comment',
+        createdAt: new Date('2023-01-01'),
+        updatedAt: new Date('2023-01-01'),
+        id: '2',
+        userId: '1',
+      },
+    ];
+
+    const userController = new UserController(
+      new MockUserControllerInboundPort({ readCommentsByUserId: comments }),
+    );
+
+    const res = await userController.readCommentsByUserId('1');
 
     expect(res).toStrictEqual([
       {

--- a/server/src/unit-test/user/user.service.spec.ts
+++ b/server/src/unit-test/user/user.service.spec.ts
@@ -34,4 +34,51 @@ describe('UserService Spec', () => {
 
     expect(res).toStrictEqual(comments);
   });
+
+  test('Read Comments By User Id', async () => {
+    const comments: FindCommentsByUserIdOutboundPortOutputDto = [
+      {
+        articleId: '1',
+        content: '1 test comment',
+        createdAt: new Date('2023-01-01'),
+        updatedAt: new Date('2023-01-01'),
+        id: '1',
+        userId: '1',
+      },
+      {
+        articleId: '2',
+        content: '2 test comment',
+        createdAt: new Date('2023-01-01'),
+        updatedAt: new Date('2023-01-01'),
+        id: '2',
+        userId: '1',
+      },
+    ];
+
+    const userService = new UserService(
+      new MockUserRepositoryOutboundPort(null),
+      new MockCommentRepositoryOutboundPort({ findCommentsByUserId: comments }),
+    );
+
+    const res = await userService.readCommentsByUserId({ userId: '1' });
+
+    expect(res).toStrictEqual([
+      {
+        articleId: '1',
+        content: '1 test comment',
+        createdAt: new Date('2023-01-01'),
+        updatedAt: new Date('2023-01-01'),
+        id: '1',
+        userId: '1',
+      },
+      {
+        articleId: '2',
+        content: '2 test comment',
+        createdAt: new Date('2023-01-01'),
+        updatedAt: new Date('2023-01-01'),
+        id: '2',
+        userId: '1',
+      },
+    ]);
+  });
 });


### PR DESCRIPTION
## 개요

- 해당 유저이 작성한 댓글 목록을 조회할 수 있다.
- 로그인이 되어있지 않아도 된다.

## ✅ 작업 내용

- Read Comments By User Id in UserController
- Read Comments By User Id in UserService

## 🔨 변경 로직

- Get Own Comments test in Controller의 함수를 readCommentsByUserId에서 getOwnComments로 변경

## 🧨 관련 이슈

- close #33 
