### PR TITLE
Feat : Delete Comment API 작성

### DIFF
--- a/server/src/common/error-message.ts
+++ b/server/src/common/error-message.ts
@@ -20,4 +20,8 @@ export const ERROR_MESSAGE = {
     code: 400,
     message: '댓글 수정을 실패하였습니다.',
   },
+  FAIL_TO_DELETE_COMMENT: {
+    code: 400,
+    message: '댓글 삭제에 실패하였습니다.',
+  },
 };

--- a/server/src/controllers/comment.controller.ts
+++ b/server/src/controllers/comment.controller.ts
@@ -1,6 +1,7 @@
 import {
   Body,
   Controller,
+  Delete,
   Inject,
   Param,
   Post,
@@ -72,6 +73,16 @@ export class CommentController {
       userId: user.id,
       commentId: id,
       content: body.content,
+    });
+  }
+
+  // NOTE: Delete
+  @UseGuards(LoggedInGuard)
+  @Delete(':id')
+  async deleteComment(@Users() user: GetUserIdDto, @Param('id') id: string) {
+    return await this.commentControllerInboundPort.deleteComment({
+      userId: user.id,
+      commentId: id,
     });
   }
 }

--- a/server/src/inbound-ports/comment/comment-controller.inbound-port.ts
+++ b/server/src/inbound-ports/comment/comment-controller.inbound-port.ts
@@ -28,6 +28,14 @@ export type UpdateCommentInboundPortOutputDto = {
   affected: number | undefined;
 };
 
+export type DeleteCommentInboundPortInputDto = {
+  userId: string;
+  commentId: string;
+};
+export type DeleteCommentInboundPortOutputDto = {
+  affected: number | undefined;
+};
+
 export interface CommentControllerInboundPort {
   createComment(
     params: CreateCommentInboundPortInputDto,
@@ -36,4 +44,8 @@ export interface CommentControllerInboundPort {
   updateComment(
     params: UpdateCommentInboundPortInputDto,
   ): Promise<UpdateCommentInboundPortOutputDto>;
+
+  deleteComment(
+    params: DeleteCommentInboundPortInputDto,
+  ): Promise<DeleteCommentInboundPortOutputDto>;
 }

--- a/server/src/outbound-ports/comment/comment-repository.outbound-port.ts
+++ b/server/src/outbound-ports/comment/comment-repository.outbound-port.ts
@@ -36,6 +36,14 @@ export type UpdateCommentOutboundPortOutputDto = {
   affected: number | undefined;
 };
 
+export type DeleteCommentOutboundPortInputDto = {
+  userId: string;
+  commentId: string;
+};
+export type DeleteComentOutboundPortOutputDto = {
+  affected: number | undefined;
+};
+
 export interface CommentRepositoryOutboundPort {
   saveComment(
     params: SaveCommentOutboundPortInputDto,
@@ -48,4 +56,8 @@ export interface CommentRepositoryOutboundPort {
   updateComment(
     params: UpdateCommentOutboundPortInputDto,
   ): Promise<UpdateCommentOutboundPortOutputDto>;
+
+  deleteComment(
+    params: DeleteCommentOutboundPortInputDto,
+  ): Promise<DeleteComentOutboundPortOutputDto>;
 }

--- a/server/src/repositories/comment.repository.ts
+++ b/server/src/repositories/comment.repository.ts
@@ -4,6 +4,8 @@ import { ERROR_MESSAGE } from 'src/common/error-message';
 import { CommentEntity } from 'src/entities/comment/comment.entity';
 import {
   CommentRepositoryOutboundPort,
+  DeleteComentOutboundPortOutputDto,
+  DeleteCommentOutboundPortInputDto,
   FindCommentsByUserIdOutboundPortInputDto,
   FindCommentsByUserIdOutboundPortOutputDto,
   SaveCommentOutboundPortInputDto,
@@ -55,6 +57,23 @@ export class CommentRepository implements CommentRepositoryOutboundPort {
 
     if (!comment.affected) {
       throw new BadRequestException(ERROR_MESSAGE.FAIL_TO_UPDATE_COMMENT);
+    }
+
+    return { affected: comment?.affected };
+  }
+
+  async deleteComment(
+    params: DeleteCommentOutboundPortInputDto,
+  ): Promise<DeleteComentOutboundPortOutputDto> {
+    const comment = await this.commentRepository.softDelete({
+      id: params.commentId,
+      userId: params.userId,
+    });
+
+    console.log(comment);
+
+    if (!comment.affected) {
+      throw new BadRequestException(ERROR_MESSAGE.FAIL_TO_DELETE_COMMENT);
     }
 
     return { affected: comment?.affected };

--- a/server/src/services/comment.service.ts
+++ b/server/src/services/comment.service.ts
@@ -3,6 +3,8 @@ import {
   CommentControllerInboundPort,
   CreateCommentInboundPortInputDto,
   CreateCommentInboundPortOutputDto,
+  DeleteCommentInboundPortInputDto,
+  DeleteCommentInboundPortOutputDto,
   UpdateCommentInboundPortInputDto,
   UpdateCommentInboundPortOutputDto,
 } from 'src/inbound-ports/comment/comment-controller.inbound-port';
@@ -36,5 +38,11 @@ export class CommentService implements CommentControllerInboundPort {
     params: UpdateCommentInboundPortInputDto,
   ): Promise<UpdateCommentInboundPortOutputDto> {
     return this.commentRepositoryOutboundPort.updateComment(params);
+  }
+
+  async deleteComment(
+    params: DeleteCommentInboundPortInputDto,
+  ): Promise<DeleteCommentInboundPortOutputDto> {
+    return this.commentRepositoryOutboundPort.deleteComment(params);
   }
 }


### PR DESCRIPTION
## 개요

- 자신의 댓글을 지울 수 있다.
- 로그인이 되어 있어야 한다.
- param: commentId

## ✅ 작업 내용

- deleteComment in CommentController
- deleteComment in CommentService
- deleteComment in CommentRepository
- add FAIL_TO_DELETE_COMMENT Error message

## 🔨 변경 로직


## 🧨 관련 이슈

- #27 
