### PR TITLE
TEST : Delete Comment Test 작성

### DIFF
--- a/server/src/outbound-ports/comment/comment-repository.outbound-port.ts
+++ b/server/src/outbound-ports/comment/comment-repository.outbound-port.ts
@@ -40,7 +40,7 @@ export type DeleteCommentOutboundPortInputDto = {
   userId: string;
   commentId: string;
 };
-export type DeleteComentOutboundPortOutputDto = {
+export type DeleteCommentOutboundPortOutputDto = {
   affected: number | undefined;
 };
 
@@ -59,5 +59,5 @@ export interface CommentRepositoryOutboundPort {
 
   deleteComment(
     params: DeleteCommentOutboundPortInputDto,
-  ): Promise<DeleteComentOutboundPortOutputDto>;
+  ): Promise<DeleteCommentOutboundPortOutputDto>;
 }

--- a/server/src/repositories/comment.repository.ts
+++ b/server/src/repositories/comment.repository.ts
@@ -4,7 +4,7 @@ import { ERROR_MESSAGE } from 'src/common/error-message';
 import { CommentEntity } from 'src/entities/comment/comment.entity';
 import {
   CommentRepositoryOutboundPort,
-  DeleteComentOutboundPortOutputDto,
+  DeleteCommentOutboundPortOutputDto,
   DeleteCommentOutboundPortInputDto,
   FindCommentsByUserIdOutboundPortInputDto,
   FindCommentsByUserIdOutboundPortOutputDto,
@@ -64,7 +64,7 @@ export class CommentRepository implements CommentRepositoryOutboundPort {
 
   async deleteComment(
     params: DeleteCommentOutboundPortInputDto,
-  ): Promise<DeleteComentOutboundPortOutputDto> {
+  ): Promise<DeleteCommentOutboundPortOutputDto> {
     const comment = await this.commentRepository.softDelete({
       id: params.commentId,
       userId: params.userId,

--- a/server/src/unit-test/comment/comment.controller.spec.ts
+++ b/server/src/unit-test/comment/comment.controller.spec.ts
@@ -3,6 +3,8 @@ import {
   CommentControllerInboundPort,
   CreateCommentInboundPortInputDto,
   CreateCommentInboundPortOutputDto,
+  DeleteCommentInboundPortInputDto,
+  DeleteCommentInboundPortOutputDto,
   UpdateCommentInboundPortInputDto,
   UpdateCommentInboundPortOutputDto,
 } from 'src/inbound-ports/comment/comment-controller.inbound-port';
@@ -11,6 +13,7 @@ import { SaveCommentOutboundPortInputDto } from 'src/outbound-ports/comment/comm
 type MockCommentControllerInboundPortParamType = {
   createComment?: CreateCommentInboundPortOutputDto;
   updateComment?: UpdateCommentInboundPortOutputDto;
+  deleteComment?: DeleteCommentInboundPortOutputDto;
 };
 
 class MockCommentControllerInboundPort implements CommentControllerInboundPort {
@@ -30,6 +33,12 @@ class MockCommentControllerInboundPort implements CommentControllerInboundPort {
     params: UpdateCommentInboundPortInputDto,
   ): Promise<UpdateCommentInboundPortOutputDto> {
     return this.result.updateComment;
+  }
+
+  async deleteComment(
+    params: DeleteCommentInboundPortInputDto,
+  ): Promise<DeleteCommentInboundPortOutputDto> {
+    return this.result.deleteComment;
   }
 }
 
@@ -73,6 +82,18 @@ describe('CommentController Spec', () => {
     const res = await commentController.updateComment({ id: '1' }, '1', {
       content: 'test content',
     });
+
+    expect(res).toStrictEqual({ affected: 1 });
+  });
+
+  test('Delete Comment', async () => {
+    const affected = { affected: 1 };
+
+    const commentController = new CommentController(
+      new MockCommentControllerInboundPort({ deleteComment: affected }),
+    );
+
+    const res = await commentController.deleteComment({ id: '1' }, '1');
 
     expect(res).toStrictEqual({ affected: 1 });
   });

--- a/server/src/unit-test/comment/comment.service.spec.ts
+++ b/server/src/unit-test/comment/comment.service.spec.ts
@@ -1,5 +1,7 @@
 import {
   CommentRepositoryOutboundPort,
+  DeleteCommentOutboundPortOutputDto,
+  DeleteCommentOutboundPortInputDto,
   FindCommentsByUserIdOutboundPortInputDto,
   FindCommentsByUserIdOutboundPortOutputDto,
   SaveCommentOutboundPortInputDto,
@@ -13,6 +15,7 @@ export type MockCommentRepositoryOutboundPortParamType = {
   saveComment?: SaveCommentOutboundPortOutputDto;
   findCommentsByUserId?: FindCommentsByUserIdOutboundPortOutputDto;
   updateComment?: UpdateCommentOutboundPortOutputDto;
+  deleteComment?: DeleteCommentOutboundPortOutputDto;
 };
 
 export class MockCommentRepositoryOutboundPort
@@ -40,6 +43,12 @@ export class MockCommentRepositoryOutboundPort
     params: UpdateCommentOutboundPortInputDto,
   ): Promise<UpdateCommentOutboundPortOutputDto> {
     return this.result.updateComment;
+  }
+
+  async deleteComment(
+    params: DeleteCommentOutboundPortInputDto,
+  ): Promise<DeleteCommentOutboundPortOutputDto> {
+    return this.result.deleteComment;
   }
 }
 
@@ -82,6 +91,21 @@ describe('CommentService Spec', () => {
       commentId: '1',
       userId: '1',
       content: 'test comment',
+    });
+
+    expect(res).toStrictEqual({ affected: 1 });
+  });
+
+  test('Delete Comment', async () => {
+    const affected = { affected: 1 };
+
+    const commentService = new CommentService(
+      new MockCommentRepositoryOutboundPort({ deleteComment: affected }),
+    );
+
+    const res = await commentService.deleteComment({
+      commentId: '1',
+      userId: '1',
     });
 
     expect(res).toStrictEqual({ affected: 1 });


### PR DESCRIPTION
## 개요

- 댓글 삭제에 대한 테스트를 실행할 수 있다.

## ✅ 작업 내용

- deleteComment test in CommentController
- deleteComment test in CommentService

## 🔨 변경 로직

- DeleteCommentOutboundPortOutputDto 오타수정

## 🧨 관련 이슈

- close #27 
